### PR TITLE
MTB-254-Bug-Filter

### DIFF
--- a/frontend/src/pages/HomePage/components/Main/Main.tsx
+++ b/frontend/src/pages/HomePage/components/Main/Main.tsx
@@ -34,7 +34,8 @@ function Main({ isSearchPage = false }: IMainProps) {
   const [getMezonApp, { isError, error }] = useLazyMezonAppControllerSearchMezonAppQuery()
 
   const [searchParams, setSearchParams] = useSearchParams()
-  const defaultSearchQuery = useMemo(() => searchParams.get('q')?.trim() || '', [searchParams.get('q')?.trim()])
+  const queryParam = searchParams.get('q');
+  const defaultSearchQuery = useMemo(() => queryParam?.trim() || '', [queryParam]);
   const defaultTagIds = useMemo(
     () => searchParams.get('tags')?.split(',').filter(Boolean) || [],
     [searchParams.get('tags')]
@@ -56,13 +57,21 @@ function Main({ isSearchPage = false }: IMainProps) {
 
   useEffect(() => {
     getTagList()
-    if (!isInitialized && isSearchPage) {
-      setSearchQuery(defaultSearchQuery)
-      setTagIds(defaultTagIds)
-      searchMezonAppList(defaultSearchQuery, defaultTagIds)
-      setIsInitialized(true)
-    }
   }, [])
+
+  useEffect(() => {
+    if (!isSearchPage) return;
+
+    setSearchQuery(defaultSearchQuery);
+    setTagIds(defaultTagIds);
+    setType(defaultType);
+
+    if (isInitialized || defaultSearchQuery || defaultTagIds.length || defaultType) {
+      searchMezonAppList(defaultSearchQuery, defaultTagIds, defaultType);
+    }
+
+    setIsInitialized(true);
+  }, [searchParams, page, botPerPage, selectedSort]);
 
   useEffect(() => {
     if (isError && error) {


### PR DESCRIPTION
When redirect to search page, web call 2 search api
The first one is called when reload main page cuz search page use same layout with main
<img width="1181" height="435" alt="image" src="https://github.com/user-attachments/assets/cd174af9-9bb1-467a-8e71-b33f20ca11f9" />

The other api is the expected api when use filtering
<img width="1151" height="430" alt="image" src="https://github.com/user-attachments/assets/373c3251-7c3b-4c69-ae02-921770ec6355" />

To fix the bug, I replaced the useEffect()[] when web calling to main page by the other one that has clear conditions to separate the main and search page
<img width="919" height="424" alt="image" src="https://github.com/user-attachments/assets/81c39e12-4bcf-40b6-9863-95a8eee28469" />
