### PR TITLE
MTB-218-commit-fixed-logic-check-ownership

### DIFF
--- a/frontend/src/pages/BotDetailPage/BotDetailPage.tsx
+++ b/frontend/src/pages/BotDetailPage/BotDetailPage.tsx
@@ -31,6 +31,8 @@ import Button from '@app/mtb-ui/Button'
 import { debounce } from 'lodash'
 import { transformMediaSrc } from '@app/utils/stringHelper'
 import { useAuth } from '@app/hook/useAuth'
+import { IUserStore } from '@app/store/user'
+
 function BotDetailPage() {
   const navigate = useNavigate()
   const [getMezonAppDetail, { isError, error, data: getMezonAppDetailApiResponse }] = useLazyMezonAppControllerGetMezonAppDetailQuery()
@@ -42,6 +44,7 @@ function BotDetailPage() {
   const { botId } = useParams()
   const { mezonAppDetail, relatedMezonApp } = useSelector<RootState, IMezonAppStore>((s) => s.mezonApp)
   const { ratings, allRatings } = useSelector<RootState, IRatingStore>((s) => s.rating)
+  const { userInfo } = useSelector<RootState, IUserStore>((s) => s.user)
   const { checkOwnership } = useOwnershipCheck();
   const ratingCounts = allRatings?.data?.reduce(
     (acc, rating) => {
@@ -99,13 +102,16 @@ function BotDetailPage() {
       }
     }
   }, [isError, error]);
-  useEffect(() => {
-    // TODO: improve logic
-    if (getMezonAppDetailApiResponse?.data && getMezonAppDetailApiResponse?.data?.status !== AppStatus.PUBLISHED) {
-      checkOwnership(getMezonAppDetailApiResponse.data?.owner?.id, true);
-    }
-  }, [getMezonAppDetailApiResponse])
 
+  useEffect(() => {
+    if (
+      userInfo?.id &&
+      getMezonAppDetailApiResponse?.data &&
+      getMezonAppDetailApiResponse.data.status !== AppStatus.PUBLISHED
+    ) {
+      checkOwnership(getMezonAppDetailApiResponse.data.owner?.id, true);
+    }
+  }, [getMezonAppDetailApiResponse, userInfo])
   const onLoadMore = async () => {
     if (botId && botId !== 'undefined' && botId.trim() !== '') {
       try {

--- a/frontend/src/pages/NewBotPage/NewBotPage.tsx
+++ b/frontend/src/pages/NewBotPage/NewBotPage.tsx
@@ -38,6 +38,7 @@ import { useOnSubmitBotForm } from './hooks/useOnSubmitBotForm'
 import CropImageModal from '@app/components/CropImageModal/CropImageModal'
 import { AppPricing } from '@app/enums/appPricing'
 import { mapDetailToFormData } from './helpers'
+import { IUserStore } from '@app/store/user'
 
 type StepFieldMap = {[key: number]: FieldPath<CreateMezonAppRequest>[]}
 
@@ -45,6 +46,7 @@ function NewBotPage() {
   const [currentStep, setCurrentStep] = useState(0)
   const { mezonAppDetail } = useSelector<RootState, IMezonAppStore>((s) => s.mezonApp)
   const { tagList } = useSelector<RootState, ITagStore>((s) => s.tag)
+  const { userInfo } = useSelector<RootState, IUserStore>((s) => s.user)
   const { botId } = useParams()
   const { checkOwnership } = useOwnershipCheck()
 
@@ -112,17 +114,15 @@ function NewBotPage() {
   }, [imgUrl])
 
   useEffect(() => {
-    if (!mezonAppDetail.id || !botId) {
-      return
-    }
+    if (!mezonAppDetail.id || !botId) return;
 
-    if (!checkOwnership(mezonAppDetail.owner?.id)) {
-      return
-    }
+    if (!userInfo?.id) return;
 
-    const formData = mapDetailToFormData(mezonAppDetail)
-    reset(formData)
-  }, [mezonAppDetail.id, botId, reset])
+    if (!checkOwnership(mezonAppDetail.owner?.id)) return;
+
+    const formData = mapDetailToFormData(mezonAppDetail);
+    reset(formData);
+  }, [mezonAppDetail.id, botId, userInfo?.id, reset]);
 
   const handleBeforeUpload = (file: File) => {
     if (!imageMimeTypes.includes(file.type)) {


### PR DESCRIPTION
When the page reloads:
 + botId already exists --> so getMezonAppDetails is called
 + However, the Redux userInfo is not yet available (because Redux is still fetching the user data)
<img width="928" height="163" alt="image" src="https://github.com/user-attachments/assets/4dff408d-67c2-411d-a41a-df05eea1c4d2" />
--> checkOwnership() runs before userInfo is loaded