### PR TITLE
MTB-385: add Open Graph and Twitter meta tags for social preview

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -12,7 +12,9 @@
   <meta property="og:title" content="Mezon Top Board" />
   <meta property="og:description"
     content="Discover and explore applications available on the Mezon platform with our comprehensive directory listing." />
-  <meta property="og:image" content="./public/assets/images/share-screen.png" />
+  <meta property="og:image" content="https://top.mezon.ai/assets/images/share-screen.png" />
+  <meta property="og:image:width" content="1470" />
+  <meta property="og:image:height" content="692" />
   <meta property="og:url" content="https://top.mezon.ai/" />
   <meta property="og:type" content="website" />
 
@@ -21,7 +23,7 @@
   <meta name="twitter:description"
     content="Discover and explore applications available on the Mezon platform with our comprehensive directory listing." />
   <meta name="twitter:url" content="https://top.mezon.ai/">
-  <meta name="twitter:image" content="./public/assets/images/share-screen.png" />
+  <meta name="twitter:image" content="https://top.mezon.ai/assets/images/share-screen.png" />
   <meta name="twitter:site" content="@mezon" />
 
   <link rel="icon" type="image/svg+xml" href="./public/assets/images/favicon.png" />


### PR DESCRIPTION
## Issue
- When sharing the site URL on Facebook, Twitter, or LinkedIn, no preview image appeared.
- Missing or relative `og:image` and `twitter:image` URLs prevented crawlers from fetching images.

## Fix
- Added proper Open Graph meta tags (`og:title`, `og:description`, `og:image`, `og:image:width`, `og:image:height`, `og:url`, `og:type`).
- Updated Twitter Card tags with absolute image URL.
- Image dimensions included to avoid Facebook async processing warning.

## Testing
- Tested locally using `ngrok` and Facebook Sharing Debugger.
- Tested locally using LocalHost Open Graph checker extension and twitter post preview
- Debugger now displays the preview image correctly.

## Related Files
- `frontend/index.html`