### PR TITLE
MTB-388-BE-Update-EndPoint-Edit-User

### DIFF
--- a/backend/src/features/mezon-app/mezon-app.service.ts
+++ b/backend/src/features/mezon-app/mezon-app.service.ts
@@ -160,6 +160,7 @@ export class MezonAppService {
         id: owner.id,
         name: owner.name,
         profileImage: owner.profileImage,
+        isVerified: owner.isVerified,
       };
     }
 
@@ -651,6 +652,7 @@ export class MezonAppService {
           id: entity.owner.id,
           name: entity.owner.name,
           profileImage: entity.owner.profileImage,
+          isVerified: entity.owner.isVerified,
         }
         mappedMezonApp.isFavorited = favoritesMap.get(entity.id) || false;
         return mappedMezonApp;

--- a/backend/src/features/user/dtos/request.ts
+++ b/backend/src/features/user/dtos/request.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional, OmitType } from "@nestjs/swagger";
 
-import { IsOptional, IsString, IsUUID, MaxLength, MinLength } from "class-validator";
+import { IsOptional, IsString, IsUUID, IsBoolean, MaxLength, MinLength } from "class-validator";
 
 import { PaginationQuery, RequestWithId } from "@domain/common/dtos/request.dto";
 import { Role } from "@domain/common/enum/role";
@@ -39,6 +39,10 @@ export class UpdateUserRequest extends RequestWithId {
   @ApiPropertyOptional()
   @IsOptional()
   profileImage: string;
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsBoolean()
+  isVerified?: boolean;
 }
 
 export class SelfUpdateUserRequest extends OmitType(UpdateUserRequest, ["id", "role"]) { }

--- a/backend/src/features/user/dtos/request.ts
+++ b/backend/src/features/user/dtos/request.ts
@@ -45,4 +45,4 @@ export class UpdateUserRequest extends RequestWithId {
   isVerified?: boolean;
 }
 
-export class SelfUpdateUserRequest extends OmitType(UpdateUserRequest, ["id", "role"]) { }
+export class SelfUpdateUserRequest extends OmitType(UpdateUserRequest, ["id", "role", "isVerified"]) { }

--- a/backend/src/features/user/dtos/response.ts
+++ b/backend/src/features/user/dtos/response.ts
@@ -12,6 +12,9 @@ export class OwnerInMezonAppDetailResponse {
     @Expose()
     @ApiProperty()
     public profileImage: string;
+    @Expose()
+    @ApiProperty()
+    public isVerified: boolean;
 }
 
 export class SearchUserResponse {
@@ -39,6 +42,9 @@ export class SearchUserResponse {
     @Expose()
     @ApiProperty()
     public deletedAt: Date | null;
+    @Expose()
+    @ApiProperty()
+    public isVerified: boolean;
 }
 
 export class ReviewerResponse {
@@ -64,4 +70,5 @@ export class OwnerInAppRatingResponse extends PickType(SearchUserResponse, [
     "id",
     "name",
     "profileImage",
+    "isVerified"
 ]) { }

--- a/backend/src/features/user/user.service.ts
+++ b/backend/src/features/user/user.service.ts
@@ -90,6 +90,7 @@ export class UserService {
       name: req.name,
       bio: req.bio,
       role: req.role,
+      isVerified: req.isVerified,
     });
     return new Result();
   }


### PR DESCRIPTION
### Issue
Admins cannot update a user's verification status via the API. The `isVerified` field is not exposed in any response DTO nor accepted in the `updateUser` endpoint.

### Root Cause
The `UpdateUserRequest` DTO lacked the `isVerified` field, and response DTOs did not include it. The service did not pass the field to the repository.

### Changes
- Added optional `isVerified` field to `UpdateUserRequest` with validation.
- Added `isVerified` to all relevant response DTOs:
  - `SearchUserResponse`
  - `OwnerInMezonAppDetailResponse`
  - `OwnerInAppRatingResponse` (via `PickType`)
- Updated `UserService.updateUser` to include `isVerified` in the update payload.
- Fixed `MezonAppService` owner mappings to include `isVerified` where `OwnerInMezonAppDetailResponse` is used.

### API Testing
1. **Update user (admin only)**  
   `PUT /api/user`  
   Body: `{ "id": "<user-id>", "isVerified": true }`  
   → Returns 200.

2. **Verify response includes field**  
   `GET /api/user/me`  
   → Response contains `"isVerified": true`.

3. **Public profile**  
   `GET /api/user/public?userId=<id>`  
   → Includes `isVerified` for badge display.

### Related Files
- `backend/src/features/user/dtos/request.ts`
- `backend/src/features/user/dtos/response.ts`
- `backend/src/features/user/user.service.ts`
- `backend/src/features/mezon-app/mezon-app.service.ts`