### PR TITLE
 MTB‑391 – BE – Add Collection and CollectionApp entities with migration

### DIFF
--- a/backend/src/domain/entities/index.ts
+++ b/backend/src/domain/entities/index.ts
@@ -12,4 +12,5 @@ export * from "./schema/appVersion.entity"
 export * from "./schema/tempFile.entity"
 export * from "./schema/favorite-app.entity"
 export * from "./schema/appTranslation.entity"
-
+export * from "./schema/collection.entity";
+export * from "./schema/collection-app.entity";

--- a/backend/src/domain/entities/schema/app.entity.ts
+++ b/backend/src/domain/entities/schema/app.entity.ts
@@ -1,13 +1,14 @@
 import { Column, Entity, JoinColumn, JoinTable, ManyToMany, ManyToOne, OneToMany, PrimaryColumn, Unique } from "typeorm";
 
 import { AppStatus } from "@domain/common/enum/appStatus";
-import { Link, AppReviewHistory, Rating, Tag, User, AppVersion, FavoriteApp } from "@domain/entities";
+import { Link, AppReviewHistory, Rating, Tag, User, AppVersion, FavoriteApp, Collection } from "@domain/entities";
 
 import { BaseSoftDelete } from "../base";
 import { MezonAppType } from "@domain/common/enum/mezonAppType";
 import { AppPricing } from "@domain/common/enum/appPricing";
 import { BaseApp } from "@domain/entities/base/baseApp.entity";
 import { AppTranslation } from "./appTranslation.entity";
+import {CollectionApp} from "@domain/entities/schema/collection-app.entity";
 
 @Entity()
 export class App extends BaseApp {
@@ -58,4 +59,7 @@ export class App extends BaseApp {
 
     @OneToMany(() => AppTranslation, (appTranslation) => appTranslation.app)
     public appTranslations: AppTranslation[];
+
+    @OneToMany(() => CollectionApp, (collectionApp) => collectionApp.app)
+    public collectionApps: CollectionApp[];
 }

--- a/backend/src/domain/entities/schema/collection-app.entity.ts
+++ b/backend/src/domain/entities/schema/collection-app.entity.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "typeorm";
+
+import { Collection } from "@domain/entities";
+
+import { App } from "./app.entity";
+
+@Entity({ name: "collection_app" })
+export class CollectionApp {
+    @PrimaryColumn({ type: "uuid" })
+    public collectionId: string;
+
+    @PrimaryColumn({ type: "uuid" })
+    public appId: string;
+
+    @Column({ type: "integer", default: 0 })
+    public order: number;
+
+    @ManyToOne(() => Collection, (collection) => collection.collectionApps, {
+        onDelete: "CASCADE",
+    })
+    @JoinColumn({ name: "collectionId" })
+    public collection: Collection;
+
+    @ManyToOne(() => App, (app) => app.collectionApps, {
+        onDelete: "CASCADE",
+    })
+    @JoinColumn({ name: "appId" })
+    public app: App;
+}

--- a/backend/src/domain/entities/schema/collection.entity.ts
+++ b/backend/src/domain/entities/schema/collection.entity.ts
@@ -1,0 +1,42 @@
+import { Column, Entity, JoinColumn, ManyToOne, OneToMany } from "typeorm";
+
+import { CollectionApp } from "@domain/entities";
+
+import { BaseSoftDelete } from "../base";
+
+
+import { User } from "./user.entity";
+
+export enum CollectionStatus {
+    PRIVATE = "PRIVATE",
+    PUBLISHED = "PUBLISHED",
+}
+
+@Entity({ name: "collection" })
+export class Collection extends BaseSoftDelete {
+    @Column({ type: "varchar", length: 255 })
+    public title: string;
+
+    @Column({ type: "text", nullable: true })
+    public description: string | null;
+
+    @Column({ type: "varchar", nullable: true })
+    public featuredImage: string | null;
+
+    @Column({
+        type: "enum",
+        enum: CollectionStatus,
+        default: CollectionStatus.PRIVATE,
+    })
+    public status: CollectionStatus;
+
+    @Column({ type: "uuid" })
+    public ownerId: string;
+
+    @ManyToOne(() => User, (user) => user.collections, { onDelete: "CASCADE" })
+    @JoinColumn({ name: "ownerId" })
+    public owner: User;
+
+    @OneToMany(() => CollectionApp, (collectionApp) => collectionApp.collection)
+    public collectionApps: CollectionApp[];
+}

--- a/backend/src/domain/entities/schema/user.entity.ts
+++ b/backend/src/domain/entities/schema/user.entity.ts
@@ -7,7 +7,7 @@ import {
 } from "typeorm";
 
 import { Role } from "@domain/common/enum/role";
-import { App, Link, Media, Rating, TempFile, FavoriteApp } from "@domain/entities"; 
+import { App, Link, Media, Rating, TempFile, FavoriteApp, Collection } from "@domain/entities";
 
 import { BaseSoftDelete } from "../base";
 import { BotWizard } from "@domain/entities/schema/botWizard.entity";
@@ -63,4 +63,7 @@ export class User extends BaseSoftDelete {
 
     @OneToMany(() => BotWizard, (bot) => bot.owner)
     public botWizards: BotWizard[];
+
+    @OneToMany(() => Collection, (collection) => collection.owner)
+    public collections: Collection[];
 }

--- a/backend/src/migrations/1776741939455-AddCollection.ts
+++ b/backend/src/migrations/1776741939455-AddCollection.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddCollection1776741939455 implements MigrationInterface {
+    name = 'AddCollection1776741939455'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TABLE "collection_app" ("collectionId" uuid NOT NULL, "appId" uuid NOT NULL, "order" integer NOT NULL DEFAULT '0', CONSTRAINT "PK_b43a5666b54bdb85d8a145841e7" PRIMARY KEY ("collectionId", "appId"))`);
+        await queryRunner.query(`CREATE TYPE "public"."collection_status_enum" AS ENUM('PRIVATE', 'PUBLISHED')`);
+        await queryRunner.query(`CREATE TABLE "collection" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "title" character varying(255) NOT NULL, "description" text, "featuredImage" character varying, "status" "public"."collection_status_enum" NOT NULL DEFAULT 'PRIVATE', "ownerId" uuid NOT NULL, CONSTRAINT "PK_ad3f485bbc99d875491f44d7c85" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "isVerified"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "createdAt"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" ADD "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "updatedAt"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" ADD "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "deletedAt"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" ADD "deletedAt" TIMESTAMP WITH TIME ZONE`);
+        await queryRunner.query(`ALTER TABLE "collection_app" ADD CONSTRAINT "FK_b1c7116f3dabbb817dd08fbff94" FOREIGN KEY ("collectionId") REFERENCES "collection"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "collection_app" ADD CONSTRAINT "FK_19dc576c85c45d7f29e24713e8b" FOREIGN KEY ("appId") REFERENCES "app"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "collection" ADD CONSTRAINT "FK_71af9149c567d79c9532f7e47d0" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "collection" DROP CONSTRAINT "FK_71af9149c567d79c9532f7e47d0"`);
+        await queryRunner.query(`ALTER TABLE "collection_app" DROP CONSTRAINT "FK_19dc576c85c45d7f29e24713e8b"`);
+        await queryRunner.query(`ALTER TABLE "collection_app" DROP CONSTRAINT "FK_b1c7116f3dabbb817dd08fbff94"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "deletedAt"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" ADD "deletedAt" TIMESTAMP`);
+        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "updatedAt"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "createdAt"`);
+        await queryRunner.query(`ALTER TABLE "temp_file" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
+        await queryRunner.query(`ALTER TABLE "user" ADD "isVerified" boolean NOT NULL DEFAULT false`);
+        await queryRunner.query(`DROP TABLE "collection"`);
+        await queryRunner.query(`DROP TYPE "public"."collection_status_enum"`);
+        await queryRunner.query(`DROP TABLE "collection_app"`);
+    }
+
+}

--- a/backend/src/migrations/1776741939455-AddCollection.ts
+++ b/backend/src/migrations/1776741939455-AddCollection.ts
@@ -7,13 +7,6 @@ export class AddCollection1776741939455 implements MigrationInterface {
         await queryRunner.query(`CREATE TABLE "collection_app" ("collectionId" uuid NOT NULL, "appId" uuid NOT NULL, "order" integer NOT NULL DEFAULT '0', CONSTRAINT "PK_b43a5666b54bdb85d8a145841e7" PRIMARY KEY ("collectionId", "appId"))`);
         await queryRunner.query(`CREATE TYPE "public"."collection_status_enum" AS ENUM('PRIVATE', 'PUBLISHED')`);
         await queryRunner.query(`CREATE TABLE "collection" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "deletedAt" TIMESTAMP WITH TIME ZONE, "title" character varying(255) NOT NULL, "description" text, "featuredImage" character varying, "status" "public"."collection_status_enum" NOT NULL DEFAULT 'PRIVATE', "ownerId" uuid NOT NULL, CONSTRAINT "PK_ad3f485bbc99d875491f44d7c85" PRIMARY KEY ("id"))`);
-        await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "isVerified"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "createdAt"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" ADD "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`);
-        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "updatedAt"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" ADD "updatedAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now()`);
-        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "deletedAt"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" ADD "deletedAt" TIMESTAMP WITH TIME ZONE`);
         await queryRunner.query(`ALTER TABLE "collection_app" ADD CONSTRAINT "FK_b1c7116f3dabbb817dd08fbff94" FOREIGN KEY ("collectionId") REFERENCES "collection"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "collection_app" ADD CONSTRAINT "FK_19dc576c85c45d7f29e24713e8b" FOREIGN KEY ("appId") REFERENCES "app"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
         await queryRunner.query(`ALTER TABLE "collection" ADD CONSTRAINT "FK_71af9149c567d79c9532f7e47d0" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
@@ -23,13 +16,6 @@ export class AddCollection1776741939455 implements MigrationInterface {
         await queryRunner.query(`ALTER TABLE "collection" DROP CONSTRAINT "FK_71af9149c567d79c9532f7e47d0"`);
         await queryRunner.query(`ALTER TABLE "collection_app" DROP CONSTRAINT "FK_19dc576c85c45d7f29e24713e8b"`);
         await queryRunner.query(`ALTER TABLE "collection_app" DROP CONSTRAINT "FK_b1c7116f3dabbb817dd08fbff94"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "deletedAt"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" ADD "deletedAt" TIMESTAMP`);
-        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "updatedAt"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" ADD "updatedAt" TIMESTAMP NOT NULL DEFAULT now()`);
-        await queryRunner.query(`ALTER TABLE "temp_file" DROP COLUMN "createdAt"`);
-        await queryRunner.query(`ALTER TABLE "temp_file" ADD "createdAt" TIMESTAMP NOT NULL DEFAULT now()`);
-        await queryRunner.query(`ALTER TABLE "user" ADD "isVerified" boolean NOT NULL DEFAULT false`);
         await queryRunner.query(`DROP TABLE "collection"`);
         await queryRunner.query(`DROP TYPE "public"."collection_status_enum"`);
         await queryRunner.query(`DROP TABLE "collection_app"`);


### PR DESCRIPTION
**What changed:**
- Added `Collection` entity with fields: `title`, `description`, `featuredImage` (nullable), `status` (`PRIVATE` | `PUBLISHED`), `ownerId` (FK to `user`).
- Added `CollectionApp` join entity with `collectionId`, `appId`, and `order` column for deterministic ordering.
- Added `@OneToMany` relations on `User` (`user.collections`) and `App` (`app.collectionApps`).
- Generated migration `1776741939455-AddCollection.ts` via `yarn db:generate`.

**How to test:**
1. Checkout branch `MTB-391-BE-Database-and-Entity`
2. Run `yarn db:run` to apply the migration.
3. Verify tables `collection` and `collection_app` exist in local DB.
4. Confirm foreign key constraints:
   - `collection.ownerId` → `user.id`
   - `collection_app.collectionId` → `collection.id`
   - `collection_app.appId` → `app.id`

**Affected files:**
- `backend/src/domain/entities/schema/collection.entity.ts`
- `backend/src/domain/entities/schema/collection-app.entity.ts`
- `backend/src/domain/entities/schema/user.entity.ts`
- `backend/src/domain/entities/schema/app.entity.ts`
- `backend/src/domain/entities/index.ts`
- `backend/src/migrations/1776741939455-AddCollection.ts`