### PR TITLE
Mtb 392 modules service controller for collection

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -22,6 +22,7 @@ import { RatingModule } from "@features/rating/rating.module";
 import { ReviewHistoryModule } from "@features/review-history/review-history.module";
 import { TagModule } from "@features/tag/tag.module";
 import { UserModule } from "@features/user/user.module";
+import { CollectionModule } from "@features/collection/collection.module";
 
 import { GuardModule } from "@libs/guard/guard.module";
 import { LoggerModule } from "@libs/logger";
@@ -82,7 +83,8 @@ import { CacheModule } from "@libs/cache";
     AppVersionModule,
     TempStorageModule,
     BotGeneratorModule,
-    FavoriteAppModule
+    FavoriteAppModule,
+    CollectionModule
   ],
   controllers: [],
   providers: [],

--- a/backend/src/features/collection/collection.controller.ts
+++ b/backend/src/features/collection/collection.controller.ts
@@ -6,9 +6,11 @@ import {
     Param,
     Post,
     Put,
-    Query,
+    Query, Req,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+
+import { Request } from "express";
 
 import { Role } from "@domain/common/enum/role";
 import { User } from "@domain/entities";
@@ -61,9 +63,10 @@ export class CollectionController {
     @OptionalAuth()
     async findOne(
         @Param("id") id: string,
-        @GetUserFromHeader() user?: User
+        @Req() req: Request & { user?: User }
     ) {
-        return this.collectionService.findOne(id, user?.id);
+        const userId = req.user?.id;
+        return this.collectionService.findOne(id, userId);
     }
 
     @Put(":id")

--- a/backend/src/features/collection/collection.controller.ts
+++ b/backend/src/features/collection/collection.controller.ts
@@ -1,0 +1,87 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    Post,
+    Put,
+    Query,
+} from "@nestjs/common";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+
+import { Role } from "@domain/common/enum/role";
+import { User } from "@domain/entities";
+
+import { Public } from "@libs/decorator/authorization.decorator";
+import { GetUserFromHeader } from "@libs/decorator/getUserFromHeader.decorator";
+import { OptionalAuth } from "@libs/decorator/optionalAuth.decorator";
+import { RoleRequired } from "@libs/decorator/roles.decorator";
+
+import { CollectionService } from "./collection.service";
+import {
+    CreateCollectionDto,
+    UpdateCollectionDto,
+    SearchCollectionsDto,
+    GetMyCollectionsQueryDto,
+} from "./dtos/request";
+
+@Controller("collection")
+@ApiTags("Collection")
+export class CollectionController {
+    constructor(private readonly collectionService: CollectionService) {}
+
+    @Post()
+    @ApiBearerAuth()
+    async create(
+        @GetUserFromHeader() user: User,
+        @Body() dto: CreateCollectionDto
+    ) {
+        return this.collectionService.create(user.id, dto);
+    }
+
+    @Get("my")
+    @ApiBearerAuth()
+    async getMyCollections(
+        @GetUserFromHeader() user: User,
+        @Query() query: GetMyCollectionsQueryDto
+    ) {
+        return this.collectionService.findMyCollections(user.id, query);
+    }
+
+    @Get("admin/search")
+    @ApiBearerAuth()
+    @RoleRequired([Role.ADMIN])
+    async adminSearch(@Query() query: SearchCollectionsDto) {
+        return this.collectionService.adminSearch(query);
+    }
+
+    @Get(":id")
+    @Public()
+    @OptionalAuth()
+    async findOne(
+        @Param("id") id: string,
+        @GetUserFromHeader() user?: User
+    ) {
+        return this.collectionService.findOne(id, user?.id);
+    }
+
+    @Put(":id")
+    @ApiBearerAuth()
+    async update(
+        @Param("id") id: string,
+        @GetUserFromHeader() user: User,
+        @Body() dto: UpdateCollectionDto
+    ) {
+        return this.collectionService.update(id, user.id, dto);
+    }
+
+    @Delete(":id")
+    @ApiBearerAuth()
+    async delete(
+        @Param("id") id: string,
+        @GetUserFromHeader() user: User
+    ) {
+        return this.collectionService.delete(id, user.id);
+    }
+}

--- a/backend/src/features/collection/collection.module.ts
+++ b/backend/src/features/collection/collection.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+
+import { Collection, CollectionApp } from "@domain/entities";
+import { App } from "@domain/entities";
+
+import { CollectionController } from "./collection.controller";
+import { CollectionService } from "./collection.service";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Collection, CollectionApp, App])],
+  providers: [CollectionService],
+  controllers: [CollectionController],
+  exports: [CollectionService],
+})
+export class CollectionModule {}

--- a/backend/src/features/collection/collection.service.ts
+++ b/backend/src/features/collection/collection.service.ts
@@ -36,6 +36,10 @@ export class CollectionService {
     async create(userId: string, dto: CreateCollectionDto): Promise<Collection> {
         const { appIds, ...collectionData } = dto;
 
+        if (appIds && appIds.length > 0) {
+            await this.validateAppOwnership(appIds, userId);
+        }
+
         const collection = await this.collectionRepo.create({
             ...collectionData,
             ownerId: userId,
@@ -52,7 +56,7 @@ export class CollectionService {
         userId: string,
         query: GetMyCollectionsQueryDto
     ) {
-        const { pageNumber = 1, pageSize = 10, status } = query;
+        const { pageNumber, pageSize, status } = query;
 
         const qb = this.collectionRepo
             .getRepository()
@@ -146,6 +150,10 @@ export class CollectionService {
 
         const { appIds, ...updateData } = dto;
 
+        if (appIds !== undefined) {
+            await this.validateAppOwnership(appIds, userId);
+        }
+
         await this.collectionRepo.update(id, updateData);
 
         if (appIds !== undefined) {
@@ -214,20 +222,31 @@ export class CollectionService {
         return { data: collections, total };
     }
 
-    private async setCollectionApps(
-        collectionId: string,
-        appIds: string[]
-    ): Promise<void> {
-        // Verify all apps exist and are published
-        const apps = await this.appRepo.find({
-            where: { id: In(appIds) },
-        });
+    private async validateAppOwnership(appIds: string[], userId: string): Promise<void> {
+        const user = await this.manager.getRepository(User).findOne({ where: { id: userId } });
+        if (!user) throw new BadRequestException("User not found");
+
+        const apps = await this.appRepo.find({ where: { id: In(appIds) } });
 
         if (apps.length !== appIds.length) {
-            throw new BadRequestException("One or more apps not found");
+            const foundIds = apps.map((a) => a.id);
+            const missingIds = appIds.filter((id) => !foundIds.includes(id));
+            throw new BadRequestException(`Apps not found: ${missingIds.join(", ")}`);
         }
 
-        // Delete existing relations
+        if (user.role !== Role.ADMIN) {
+            const notOwnedApps = apps.filter((app) => app.ownerId !== userId);
+            if (notOwnedApps.length > 0) {
+                throw new ForbiddenException(
+                    `You can only add your own apps. Apps with IDs: ${notOwnedApps
+                        .map((a) => a.id)
+                        .join(", ")} are not yours.`
+                );
+            }
+        }
+    }
+
+    private async setCollectionApps(collectionId: string, appIds: string[]): Promise<void> {
         await this.collectionAppRepo.getRepository().delete({ collectionId });
 
         // Create new relations with order

--- a/backend/src/features/collection/collection.service.ts
+++ b/backend/src/features/collection/collection.service.ts
@@ -1,0 +1,242 @@
+import {
+    BadRequestException,
+    ForbiddenException,
+    Injectable,
+    NotFoundException,
+} from "@nestjs/common";
+
+import { EntityManager, In } from "typeorm";
+
+import { Role } from "@domain/common/enum/role";
+import { Collection, CollectionApp } from "@domain/entities";
+import { App } from "@domain/entities";
+import { User } from "@domain/entities";
+import { CollectionStatus } from "@domain/entities/schema/collection.entity";
+
+import { GenericRepository } from "@libs/repository/genericRepository";
+
+import {
+    CreateCollectionDto,
+    UpdateCollectionDto,
+    SearchCollectionsDto, GetMyCollectionsQueryDto,
+} from "./dtos/request";
+
+@Injectable()
+export class CollectionService {
+    private readonly collectionRepo: GenericRepository<Collection>;
+    private readonly collectionAppRepo: GenericRepository<CollectionApp>;
+    private readonly appRepo: GenericRepository<App>;
+
+    constructor(private readonly manager: EntityManager) {
+        this.collectionRepo = new GenericRepository(Collection, manager);
+        this.collectionAppRepo = new GenericRepository(CollectionApp, manager);
+        this.appRepo = new GenericRepository(App, manager);
+    }
+
+    async create(userId: string, dto: CreateCollectionDto): Promise<Collection> {
+        const { appIds, ...collectionData } = dto;
+
+        const collection = await this.collectionRepo.create({
+            ...collectionData,
+            ownerId: userId,
+        });
+
+        if (appIds && appIds.length > 0) {
+            await this.setCollectionApps(collection.id, appIds);
+        }
+
+        return this.findOne(collection.id, userId);
+    }
+
+    async findMyCollections(
+        userId: string,
+        query: GetMyCollectionsQueryDto
+    ) {
+        const { pageNumber = 1, pageSize = 10, status } = query;
+
+        const qb = this.collectionRepo
+            .getRepository()
+            .createQueryBuilder("collection")
+            .leftJoinAndSelect("collection.collectionApps", "collectionApps")
+            .leftJoinAndSelect("collectionApps.app", "app")
+            .leftJoinAndSelect("app.appTranslations", "translations")
+            .where("collection.ownerId = :userId", { userId });
+
+        if (status) {
+            qb.andWhere("collection.status = :status", { status });
+        }
+
+        qb.orderBy("collection.createdAt", "DESC")
+            .skip((pageNumber - 1) * pageSize)
+            .take(pageSize);
+
+        const [collections, total] = await qb.getManyAndCount();
+
+        return { data: collections, total };
+    }
+
+    async findOne(id: string, userId?: string): Promise<Collection> {
+        const collection = await this.collectionRepo.getRepository().findOne({
+            where: { id },
+            relations: [
+                "owner",
+                "collectionApps",
+                "collectionApps.app",
+                "collectionApps.app.appTranslations",
+                "collectionApps.app.tags",
+            ],
+            order: {
+                collectionApps: {
+                    order: "ASC",
+                },
+            },
+        });
+
+        if (!collection) {
+            throw new NotFoundException("Collection not found");
+        }
+
+        // If collection is private, only owner or admin can view
+        if (collection.status === CollectionStatus.PRIVATE) {
+            if (!userId) {
+                throw new NotFoundException("Collection not found");
+            }
+
+            const user = await this.manager
+                .getRepository(User)
+                .findOne({ where: { id: userId } });
+
+            if (!user) {
+                throw new NotFoundException("Collection not found");
+            }
+
+            if (collection.ownerId !== userId && user.role !== Role.ADMIN) {
+                throw new NotFoundException("Collection not found");
+            }
+        }
+
+        return collection;
+    }
+
+    async update(
+        id: string,
+        userId: string,
+        dto: UpdateCollectionDto
+    ): Promise<Collection> {
+        const collection = await this.collectionRepo.findOne({
+            where: { id },
+            relations: ["owner"],
+        });
+
+        if (!collection) {
+            throw new NotFoundException("Collection not found");
+        }
+
+        const user = await this.manager
+            .getRepository(User)
+            .findOne({ where: { id: userId } });
+
+        if (!user) {
+            throw new ForbiddenException("User not found");
+        }
+
+        if (collection.ownerId !== userId && user.role !== Role.ADMIN) {
+            throw new ForbiddenException("You do not have permission to update this collection");
+        }
+
+        const { appIds, ...updateData } = dto;
+
+        await this.collectionRepo.update(id, updateData);
+
+        if (appIds !== undefined) {
+            await this.setCollectionApps(id, appIds);
+        }
+
+        return this.findOne(id, userId);
+    }
+
+    async delete(id: string, userId: string): Promise<void> {
+        const collection = await this.collectionRepo.findOne({
+            where: { id },
+            relations: ["owner"],
+        });
+
+        if (!collection) {
+            throw new NotFoundException("Collection not found");
+        }
+
+        const user = await this.manager
+            .getRepository(User)
+            .findOne({ where: { id: userId } });
+
+        if (!user) {
+            throw new ForbiddenException("User not found");
+        }
+
+        if (collection.ownerId !== userId && user.role !== Role.ADMIN) {
+            throw new ForbiddenException("You do not have permission to delete this collection");
+        }
+
+        await this.collectionRepo.softDelete(id);
+    }
+
+    async adminSearch(query: SearchCollectionsDto) {
+        const { search, status, ownerId, pageNumber, pageSize } = query;
+
+        const qb = this.collectionRepo
+            .getRepository()
+            .createQueryBuilder("collection")
+            .leftJoinAndSelect("collection.owner", "owner")
+            .leftJoinAndSelect("collection.collectionApps", "collectionApps")
+            .loadRelationCountAndMap(
+                "collection.appCount",
+                "collection.collectionApps"
+            );
+
+        if (search) {
+            qb.andWhere("collection.title ILIKE :search", { search: `%${search}%` });
+        }
+
+        if (status) {
+            qb.andWhere("collection.status = :status", { status });
+        }
+
+        if (ownerId) {
+            qb.andWhere("collection.ownerId = :ownerId", { ownerId });
+        }
+
+        qb.orderBy("collection.createdAt", "DESC")
+            .skip((pageNumber - 1) * pageSize)
+            .take(pageSize);
+
+        const [collections, total] = await qb.getManyAndCount();
+
+        return { data: collections, total };
+    }
+
+    private async setCollectionApps(
+        collectionId: string,
+        appIds: string[]
+    ): Promise<void> {
+        // Verify all apps exist and are published
+        const apps = await this.appRepo.find({
+            where: { id: In(appIds) },
+        });
+
+        if (apps.length !== appIds.length) {
+            throw new BadRequestException("One or more apps not found");
+        }
+
+        // Delete existing relations
+        await this.collectionAppRepo.getRepository().delete({ collectionId });
+
+        // Create new relations with order
+        const collectionApps = appIds.map((appId, index) => ({
+            collectionId,
+            appId,
+            order: index,
+        }));
+
+        await this.collectionAppRepo.getRepository().save(collectionApps);
+    }
+}

--- a/backend/src/features/collection/dtos/request.ts
+++ b/backend/src/features/collection/dtos/request.ts
@@ -1,0 +1,133 @@
+import {
+    ApiProperty,
+    ApiPropertyOptional
+} from "@nestjs/swagger";
+
+import { Transform, Type } from "class-transformer";
+import {
+    IsArray,
+    IsEnum,
+    IsInt,
+    IsNotEmpty,
+    IsOptional,
+    IsString,
+    IsUUID,
+    MaxLength,
+    Min,
+} from "class-validator";
+
+import { CollectionStatus } from "@domain/entities/schema/collection.entity";
+
+export class CreateCollectionDto {
+    @ApiProperty()
+    @IsString()
+    @IsNotEmpty()
+    @MaxLength(255)
+    @Transform(({ value }) => value?.trim())
+    title: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    @Transform(({ value }) => value?.trim())
+    description?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    featuredImage?: string;
+
+    @ApiPropertyOptional({ enum: CollectionStatus, default: CollectionStatus.PRIVATE })
+    @IsEnum(CollectionStatus)
+    @IsOptional()
+    status?: CollectionStatus;
+
+    @ApiPropertyOptional({ type: [String] })
+    @IsArray()
+    @IsUUID(undefined, { each: true })
+    @IsOptional()
+    appIds?: string[];
+}
+
+export class UpdateCollectionDto {
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    @MaxLength(255)
+    @Transform(({ value }) => value?.trim())
+    title?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    @Transform(({ value }) => value?.trim())
+    description?: string;
+
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    featuredImage?: string;
+
+    @ApiPropertyOptional({ enum: CollectionStatus })
+    @IsEnum(CollectionStatus)
+    @IsOptional()
+    status?: CollectionStatus;
+
+    @ApiPropertyOptional({ type: [String] })
+    @IsArray()
+    @IsUUID(undefined, { each: true })
+    @IsOptional()
+    appIds?: string[];
+}
+
+export class GetMyCollectionsQueryDto {
+    @ApiPropertyOptional({ default: 1 })
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @IsOptional()
+    pageNumber?: number = 1;
+
+    @ApiPropertyOptional({ default: 10 })
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @IsOptional()
+    pageSize?: number = 10;
+
+    @ApiPropertyOptional({ enum: CollectionStatus })
+    @IsEnum(CollectionStatus)
+    @IsOptional()
+    status?: CollectionStatus;
+}
+
+export class SearchCollectionsDto {
+    @ApiPropertyOptional()
+    @IsString()
+    @IsOptional()
+    search?: string;
+
+    @ApiPropertyOptional({ enum: CollectionStatus })
+    @IsEnum(CollectionStatus)
+    @IsOptional()
+    status?: CollectionStatus;
+
+    @ApiPropertyOptional()
+    @IsUUID()
+    @IsOptional()
+    ownerId?: string;
+
+    @ApiPropertyOptional({ default: 1 })
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @IsOptional()
+    pageNumber?: number = 1;
+
+    @ApiPropertyOptional({ default: 10 })
+    @Type(() => Number)
+    @IsInt()
+    @Min(1)
+    @IsOptional()
+    pageSize?: number = 10;
+}

--- a/backend/src/features/collection/dtos/response.ts
+++ b/backend/src/features/collection/dtos/response.ts
@@ -1,0 +1,67 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+import { Expose, Type } from "class-transformer";
+
+import { CollectionStatus } from "@domain/entities/schema/collection.entity";
+
+import { GetMezonAppDetailsResponse } from "@features/mezon-app/dtos/response";
+import { OwnerInMezonAppDetailResponse } from "@features/user/dtos/response";
+
+export class CollectionAppResponse {
+    @Expose()
+    @ApiProperty()
+    appId: string;
+
+    @Expose()
+    @ApiProperty()
+    order: number;
+
+    @Expose()
+    @ApiProperty({ type: () => GetMezonAppDetailsResponse })
+    @Type(() => GetMezonAppDetailsResponse)
+    app: GetMezonAppDetailsResponse;
+}
+
+export class CollectionResponse {
+    @Expose()
+    @ApiProperty()
+    id: string;
+
+    @Expose()
+    @ApiProperty()
+    title: string;
+
+    @Expose()
+    @ApiPropertyOptional()
+    description?: string;
+
+    @Expose()
+    @ApiPropertyOptional()
+    featuredImage?: string;
+
+    @Expose()
+    @ApiProperty({ enum: CollectionStatus })
+    status: CollectionStatus;
+
+    @Expose()
+    @ApiProperty()
+    ownerId: string;
+
+    @Expose()
+    @ApiProperty({ type: () => OwnerInMezonAppDetailResponse })
+    @Type(() => OwnerInMezonAppDetailResponse)
+    owner: OwnerInMezonAppDetailResponse;
+
+    @Expose()
+    @ApiProperty({ type: () => [CollectionAppResponse] })
+    @Type(() => CollectionAppResponse)
+    collectionApps: CollectionAppResponse[];
+
+    @Expose()
+    @ApiProperty()
+    createdAt: Date;
+
+    @Expose()
+    @ApiProperty()
+    updatedAt: Date;
+}


### PR DESCRIPTION
## Summary
Implements full backend CRUD for Collections, including permission checks and admin search.

## What Changed
- Added `CollectionModule` with service and controller.
- Implemented endpoints:
  - `POST /api/collection` – Create collection (auth)
  - `GET /api/collection/my` – Get user's collections (paginated, filter by status)
  - `GET /api/collection/:id` – Get single collection (public if published)
  - `PUT /api/collection/:id` – Update (owner/admin only)
  - `DELETE /api/collection/:id` – Delete (owner/admin only)
  - `GET /api/collection/admin/search` – Admin search all collections
- Enforced permission checks:
  - Users can only add their own apps (admin exempt)
  - Private collections are only visible to owner/admin
- Added DTOs with validation and Swagger docs.

## How to Test
1. Run `yarn build` and restart backend.
2. Use Swagger (`/api`) with auth tokens
3. **Create collection** – User can add only their own apps; attempting others' apps returns `403`.
4. **Visibility** – Private collection returns `404` for non‑owner/unauthenticated; published is public.
5. **Admin search** – Admin sees all collections; regular user gets `403`.
6. **Update/Delete** – Only owner/admin can modify.

## Affected Files
- `backend/src/features/collection/collection.module.ts`
- `backend/src/features/collection/collection.service.ts`
- `backend/src/features/collection/collection.controller.ts`
- `backend/src/features/collection/dtos/request.ts`
- `backend/src/features/collection/dtos/response.ts`
- `backend/src/app.module.ts`