### PR TITLE
Mtb 393: FE add types & services for collection

### DIFF
--- a/frontend/src/services/api/collection/collection.ts
+++ b/frontend/src/services/api/collection/collection.ts
@@ -1,0 +1,56 @@
+import { api } from '../../apiInstance';
+import type {
+    CreateCollectionRequest,
+    UpdateCollectionRequest,
+    GetMyCollectionsArgs,
+    AdminSearchCollectionsArgs,
+    CollectionResponse,
+    CollectionListResponse,
+} from './collection.types';
+
+const collectionService = api.injectEndpoints({
+    endpoints: (build) => ({
+        // Create collection
+        createCollection: build.mutation<CollectionResponse, CreateCollectionRequest>({
+            query: (body) => ({ url: '/api/collection', method: 'POST', body }),
+        }),
+
+        // Get user's own collections
+        getMyCollections: build.query<CollectionListResponse, GetMyCollectionsArgs>({
+            query: (params) => ({ url: '/api/collection/my', params }),
+        }),
+
+        // Get single collection (public or own)
+        getCollection: build.query<CollectionResponse, string>({
+            query: (id) => ({ url: `/api/collection/${id}` }),
+        }),
+
+        // Update collection
+        updateCollection: build.mutation<CollectionResponse, UpdateCollectionRequest>({
+            query: ({ id, ...body }) => ({ url: `/api/collection/${id}`, method: 'PUT', body }),
+        }),
+
+        // Delete collection
+        deleteCollection: build.mutation<void, string>({
+            query: (id) => ({ url: `/api/collection/${id}`, method: 'DELETE' }),
+        }),
+
+        // Admin search
+        adminSearchCollections: build.query<CollectionListResponse, AdminSearchCollectionsArgs>({
+            query: (params) => ({ url: '/api/collection/admin/search', params }),
+        }),
+    }),
+    overrideExisting: false,
+});
+
+export const {
+    useCreateCollectionMutation,
+    useGetMyCollectionsQuery,
+    useLazyGetMyCollectionsQuery,
+    useGetCollectionQuery,
+    useLazyGetCollectionQuery,
+    useUpdateCollectionMutation,
+    useDeleteCollectionMutation,
+    useAdminSearchCollectionsQuery,
+    useLazyAdminSearchCollectionsQuery,
+} = collectionService;

--- a/frontend/src/services/api/collection/collection.types.ts
+++ b/frontend/src/services/api/collection/collection.types.ts
@@ -1,0 +1,33 @@
+import { HttpResponse } from '@app/types/API.types';
+import { Collection, CollectionStatus } from '@app/types/collection.types';
+
+// DTOs for requests
+export type CreateCollectionRequest = {
+    title: string;
+    description?: string;
+    featuredImage?: string;
+    status?: CollectionStatus;
+    appIds?: string[];
+};
+
+export type UpdateCollectionRequest = Partial<CreateCollectionRequest> & {
+    id: string;
+};
+
+export type GetMyCollectionsArgs = {
+    pageNumber?: number;
+    pageSize?: number;
+    status?: CollectionStatus;
+};
+
+export type AdminSearchCollectionsArgs = {
+    search?: string;
+    status?: CollectionStatus;
+    ownerId?: string;
+    pageNumber?: number;
+    pageSize?: number;
+};
+
+// Response types wrapped in HttpResponse
+export type CollectionResponse = HttpResponse<Collection>;
+export type CollectionListResponse = HttpResponse<Collection[]>;

--- a/frontend/src/types/collection.types.ts
+++ b/frontend/src/types/collection.types.ts
@@ -1,0 +1,30 @@
+import { GetMezonAppDetailsResponse } from '@app/services/api/mezonApp/mezonApp.types';
+
+export enum CollectionStatus {
+    PRIVATE = 'PRIVATE',
+    PUBLISHED = 'PUBLISHED',
+}
+
+export interface Collection {
+    id: string;
+    title: string;
+    description?: string | null;
+    featuredImage?: string | null;
+    status: CollectionStatus;
+    ownerId: string;
+    owner: {
+        id: string;
+        name: string;
+        profileImage: string;
+    };
+    collectionApps: CollectionApp[];
+    appCount?: number;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface CollectionApp {
+    appId: string;
+    order: number;
+    app: GetMezonAppDetailsResponse;
+}


### PR DESCRIPTION
## Summary
Add TypeScript types and RTK Query API service for Collections.

## What Changed
- Defined `Collection`, `CollectionApp`, `CollectionStatus` types (`frontend/src/types/collection.types.ts`).
- Created API endpoints and hooks (`frontend/src/services/api/collection/collection.ts` and `.types.ts`):
  - `useCreateCollectionMutation`
  - `useGetMyCollectionsQuery` / `useLazyGetMyCollectionsQuery`
  - `useGetCollectionQuery` / `useLazyGetCollectionQuery`
  - `useUpdateCollectionMutation`
  - `useDeleteCollectionMutation`
  - `useAdminSearchCollectionsQuery` / `useLazyAdminSearchCollectionsQuery`

## How to Test
1. `cd frontend && yarn build` – no TypeScript errors.
2. Import any hook (e.g., `useGetMyCollectionsQuery`) in a component – no import errors.

## Affected Files
- `frontend/src/types/collection.types.ts`
- `frontend/src/services/api/collection/collection.types.ts`
- `frontend/src/services/api/collection/collection.ts`