### PR TITLE
Mtb 394 fe admin collection

### DIFF
--- a/frontend/src/navigation/adminRoutePaths.tsx
+++ b/frontend/src/navigation/adminRoutePaths.tsx
@@ -1,4 +1,4 @@
-import { AppstoreAddOutlined, HistoryOutlined, SettingOutlined, UserOutlined, LinkOutlined, TagOutlined, MailOutlined, TeamOutlined } from '@ant-design/icons'
+import { AppstoreAddOutlined, HistoryOutlined, SettingOutlined, UserOutlined, LinkOutlined, TagOutlined, MailOutlined, TeamOutlined, AppstoreOutlined } from '@ant-design/icons'
 import MezonAppsContainer from '@app/pages/AdminPage/AdminMezonApp/MezonAppsContainer'
 import ReviewHistoryPage from '@app/pages/AdminPage/ReviewHistoryPage/ReviewHistoryPage'
 import UsersList from "@app/pages/AdminPage/AdminManageUsers/UsersList";
@@ -9,6 +9,7 @@ import MailScheduleList from '@app/pages/AdminPage/AdminManageMailSchedule/MailS
 import EmailSubscriberList from '@app/pages/AdminPage/AdminManageSubscribers/SubscriberList';
 import AppReviewPage from '@app/pages/AdminPage/AppReviewPage/AppReviewPage';
 import SettingsPage from '@app/pages/AdminPage/AdminSettings/SettingsPage';
+import CollectionsPage from "@app/pages/AdminPage/AdminManageCollections/CollectionPage.tsx";
 
 export const adminRoutePaths: RoutePath[] = [
   {
@@ -17,6 +18,13 @@ export const adminRoutePaths: RoutePath[] = [
     element: <MezonAppsContainer />, 
     strLabel: 'Apps',
     icon: <AppstoreAddOutlined />,
+    isShowMenu: true
+  },
+  {
+    path: '/manage/collections',
+    element: <CollectionsPage />,
+    strLabel: 'Collections',
+    icon: <AppstoreOutlined />,
     isShowMenu: true
   },
   {

--- a/frontend/src/pages/AdminPage/AdminManageCollections/CollectionModal.tsx
+++ b/frontend/src/pages/AdminPage/AdminManageCollections/CollectionModal.tsx
@@ -2,7 +2,7 @@ import { Modal, Form, Input, Select } from 'antd';
 import { Controller, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useEffect, useState } from 'react';
-import { useLazyMezonAppControllerListAdminMezonAppQuery } from '@app/services/api/mezonApp/mezonApp';
+import { useLazyMezonAppControllerListAdminMezonAppQuery, useLazyMezonAppControllerGetMyAppQuery } from '@app/services/api/mezonApp/mezonApp';
 import { GetMezonAppDetailsResponse } from '@app/services/api/mezonApp/mezonApp.types';
 import { getAppTranslation } from '@app/hook/useAppTranslation';
 import { Collection } from '@app/types/collection.types';
@@ -19,10 +19,12 @@ interface Props {
     onSubmit: (values: any) => void;
     initialValues?: Collection | null;
     isLoading?: boolean;
+    ownerId?: string; // if provided, restricts app selection to this user's own apps (non‑admin)
 }
 
-const CollectionModal = ({ open, onClose, onSubmit, initialValues, isLoading }: Props) => {
+const CollectionModal = ({ open, onClose, onSubmit, initialValues, isLoading, ownerId }: Props) => {
     const [fetchAllApps] = useLazyMezonAppControllerListAdminMezonAppQuery();
+    const [fetchMyApps] = useLazyMezonAppControllerGetMyAppQuery();
     const [appOptions, setAppOptions] = useState<{ label: string; value: string }[]>([]);
     const [isMediaManagerOpen, setIsMediaManagerOpen] = useState(false);
 
@@ -54,19 +56,38 @@ const CollectionModal = ({ open, onClose, onSubmit, initialValues, isLoading }: 
             reset({ title: '', description: '', featuredImage: '', status: 'PRIVATE', appIds: [] });
         }
 
-        // Type assertion: cast the response to the expected shape
-        (fetchAllApps({ pageNumber: 1, pageSize: 1000, sortField: 'name', sortOrder: 'ASC' })
-            .unwrap() as Promise<{ data: GetMezonAppDetailsResponse[] }>)
-            .then(res => {
-                if (res?.data) {
-                    const allOptions = res.data.map((app: GetMezonAppDetailsResponse) => ({
-                        label: getAppTranslation(app, 'en').name,
-                        value: app.id,
-                    }));
-                    setAppOptions(allOptions);
-                }
-            });
-    }, [open, initialValues, reset, fetchAllApps]);
+        const loadApps = async () => {
+            let apps: GetMezonAppDetailsResponse[] = [];
+            if (ownerId) {
+                // User mode: fetch only own apps (published)
+                const res = await fetchMyApps({
+                    ownerId,
+                    pageNumber: 1,
+                    pageSize: 1000,
+                    sortField: 'name',
+                    sortOrder: 'ASC',
+                }).unwrap();
+                // res is expected to have { data: GetMezonAppDetailsResponse[] }
+                apps = res?.data ?? [];
+            } else {
+                // Admin mode: fetch all apps
+                const res = await fetchAllApps({
+                    pageNumber: 1,
+                    pageSize: 1000,
+                    sortField: 'name',
+                    sortOrder: 'ASC',
+                }).unwrap() as unknown as { data: GetMezonAppDetailsResponse[] };
+                apps = res?.data ?? [];
+            }
+            const options = apps.map((app) => ({
+                label: getAppTranslation(app, 'en').name,
+                value: app.id,
+            }));
+            setAppOptions(options);
+        };
+
+        loadApps().catch(() => {});
+    }, [open, initialValues, reset, fetchAllApps, fetchMyApps, ownerId]);
 
     const onFormSubmit = (data: any) => {
         onSubmit(data);

--- a/frontend/src/pages/AdminPage/AdminManageCollections/CollectionModal.tsx
+++ b/frontend/src/pages/AdminPage/AdminManageCollections/CollectionModal.tsx
@@ -1,0 +1,154 @@
+import { Modal, Form, Input, Select } from 'antd';
+import { Controller, useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
+import { useEffect, useState } from 'react';
+import { useLazyMezonAppControllerListAdminMezonAppQuery } from '@app/services/api/mezonApp/mezonApp';
+import { GetMezonAppDetailsResponse } from '@app/services/api/mezonApp/mezonApp.types';
+import { getAppTranslation } from '@app/hook/useAppTranslation';
+import { Collection } from '@app/types/collection.types';
+import { collectionSchema } from '@app/validations/collection.validation';
+import MediaManagerModal from '@app/components/MediaManager/MediaManager';
+import MtbButton from '@app/mtb-ui/Button';
+import { EditOutlined } from '@ant-design/icons';
+import TableImage from '@app/components/TableImage/TableImage';
+import { CropImageShape } from '@app/enums/CropImage.enum';
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+    onSubmit: (values: any) => void;
+    initialValues?: Collection | null;
+    isLoading?: boolean;
+}
+
+const CollectionModal = ({ open, onClose, onSubmit, initialValues, isLoading }: Props) => {
+    const [fetchAllApps] = useLazyMezonAppControllerListAdminMezonAppQuery();
+    const [appOptions, setAppOptions] = useState<{ label: string; value: string }[]>([]);
+    const [isMediaManagerOpen, setIsMediaManagerOpen] = useState(false);
+
+    const { control, handleSubmit, reset, setValue, watch, formState: { errors } } = useForm({
+        resolver: yupResolver(collectionSchema),
+        defaultValues: {
+            title: '',
+            description: '',
+            featuredImage: '',
+            status: 'PRIVATE',
+            appIds: [],
+        },
+    });
+
+    const featuredImageValue = watch('featuredImage');
+
+    useEffect(() => {
+        if (!open) return;
+
+        if (initialValues) {
+            reset({
+                title: initialValues.title,
+                description: initialValues.description || '',
+                featuredImage: initialValues.featuredImage || '',
+                status: initialValues.status,
+                appIds: initialValues.collectionApps?.map(ca => ca.appId) || [],
+            });
+        } else {
+            reset({ title: '', description: '', featuredImage: '', status: 'PRIVATE', appIds: [] });
+        }
+
+        // Type assertion: cast the response to the expected shape
+        (fetchAllApps({ pageNumber: 1, pageSize: 1000, sortField: 'name', sortOrder: 'ASC' })
+            .unwrap() as Promise<{ data: GetMezonAppDetailsResponse[] }>)
+            .then(res => {
+                if (res?.data) {
+                    const allOptions = res.data.map((app: GetMezonAppDetailsResponse) => ({
+                        label: getAppTranslation(app, 'en').name,
+                        value: app.id,
+                    }));
+                    setAppOptions(allOptions);
+                }
+            });
+    }, [open, initialValues, reset, fetchAllApps]);
+
+    const onFormSubmit = (data: any) => {
+        onSubmit(data);
+    };
+
+    const handleMediaSelect = (path: string) => {
+        setValue('featuredImage', path, { shouldValidate: true });
+        setIsMediaManagerOpen(false);
+    };
+
+    return (
+        <>
+            <Modal
+                title={initialValues ? 'Edit Collection' : 'Create Collection'}
+                open={open}
+                onCancel={onClose}
+                zIndex={2}
+                footer={[
+                    <MtbButton key="cancel" variant="outlined" onClick={onClose}>Cancel</MtbButton>,
+                    <MtbButton key="submit" loading={isLoading} onClick={handleSubmit(onFormSubmit)}>
+                        {initialValues ? 'Update' : 'Create'}
+                    </MtbButton>,
+                ]}
+                width={600}
+                centered
+            >
+                <Form layout="vertical" className="pt-4">
+                    <Form.Item label="Title" validateStatus={errors.title ? 'error' : ''} help={errors.title?.message}>
+                        <Controller name="title" control={control} render={({ field }) => <Input {...field} placeholder="Collection title" />} />
+                    </Form.Item>
+                    <Form.Item label="Description">
+                        <Controller name="description" control={control} render={({ field }) => <Input.TextArea {...field} rows={3} placeholder="Optional description" />} />
+                    </Form.Item>
+                    <Form.Item label="Featured Image">
+                        <div className="flex items-center gap-4">
+                            <TableImage src={featuredImageValue} alt="featured" size={60} />
+                            <MtbButton icon={<EditOutlined />} variant="outlined" onClick={() => setIsMediaManagerOpen(true)}>
+                                Choose Image
+                            </MtbButton>
+                        </div>
+                    </Form.Item>
+                    <Form.Item label="Status">
+                        <Controller
+                            name="status"
+                            control={control}
+                            render={({ field }) => (
+                                <Select {...field}>
+                                    <Select.Option value="PRIVATE">Private</Select.Option>
+                                    <Select.Option value="PUBLISHED">Published</Select.Option>
+                                </Select>
+                            )}
+                        />
+                    </Form.Item>
+                    <Form.Item label="Apps">
+                        <Controller
+                            name="appIds"
+                            control={control}
+                            render={({ field }) => (
+                                <Select
+                                    mode="multiple"
+                                    showSearch
+                                    placeholder="Search and select apps"
+                                    optionFilterProp="label"
+                                    onChange={(val) => field.onChange(val)}
+                                    value={field.value}
+                                    options={appOptions}
+                                    allowClear
+                                />
+                            )}
+                        />
+                    </Form.Item>
+                </Form>
+            </Modal>
+            <MediaManagerModal
+                isVisible={isMediaManagerOpen}
+                onChoose={handleMediaSelect}
+                onClose={() => setIsMediaManagerOpen(false)}
+                initialCropShape={CropImageShape.RECTANGLE}
+                showShapeSwitcher={true}
+            />
+        </>
+    );
+};
+
+export default CollectionModal;

--- a/frontend/src/pages/AdminPage/AdminManageCollections/CollectionPage.tsx
+++ b/frontend/src/pages/AdminPage/AdminManageCollections/CollectionPage.tsx
@@ -1,0 +1,189 @@
+import { useState } from 'react';
+import { Input, Table, Space, Popconfirm, Tag, Button } from 'antd';
+import { SearchOutlined, LoadingOutlined } from '@ant-design/icons';
+import {
+    useAdminSearchCollectionsQuery,
+    useCreateCollectionMutation,
+    useUpdateCollectionMutation,
+    useDeleteCollectionMutation,
+} from '@app/services/api/collection/collection';
+import { Collection } from '@app/types/collection.types';
+import TableActionButton from '@app/components/TableActionButton/TableActionButton';
+import TableImage from '@app/components/TableImage/TableImage';
+import { toast } from 'react-toastify';
+import CollectionModal from './CollectionModal';
+
+const CollectionsPage = () => {
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(10);
+    const [search, setSearch] = useState('');
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [editingCollection, setEditingCollection] = useState<Collection | null>(null);
+    const [deletingId, setDeletingId] = useState<string | null>(null);
+
+    const { data, isLoading, refetch } = useAdminSearchCollectionsQuery(
+        { search, pageNumber: page, pageSize },
+        { refetchOnMountOrArgChange: true }
+    ) as { data?: { data: Collection[]; totalCount: number }; isLoading: boolean; refetch: () => void };
+
+    const [deleteCollection] = useDeleteCollectionMutation();
+    const [createCollection, { isLoading: isCreating }] = useCreateCollectionMutation();
+    const [updateCollection, { isLoading: isUpdating }] = useUpdateCollectionMutation();
+
+    const handleDelete = async (id: string) => {
+        setDeletingId(id);
+        try {
+            await deleteCollection(id).unwrap();
+            toast.success('Collection deleted');
+            refetch();
+        } catch {
+            toast.error('Failed to delete');
+        } finally {
+            setDeletingId(null);
+        }
+    };
+
+    const handleCreateOrUpdate = async (values: any) => {
+        try {
+            if (editingCollection) {
+                await updateCollection({ id: editingCollection.id, ...values }).unwrap();
+                toast.success('Collection updated');
+            } else {
+                await createCollection(values).unwrap();
+                toast.success('Collection created');
+            }
+            setIsModalOpen(false);
+            setEditingCollection(null);
+            refetch();
+        } catch {
+            toast.error('Operation failed');
+        }
+    };
+
+    const openCreateModal = () => {
+        setEditingCollection(null);
+        setIsModalOpen(true);
+    };
+
+    const openEditModal = (record: Collection) => {
+        setEditingCollection(record);
+        setIsModalOpen(true);
+    };
+
+    const columns = [
+        {
+            title: 'Image',
+            dataIndex: 'featuredImage',
+            key: 'featuredImage',
+            width: 80,
+            render: (text: string) => <TableImage src={text} alt="collection" size={40} />,
+        },
+        {
+            title: 'Title',
+            dataIndex: 'title',
+            key: 'title',
+        },
+        {
+            title: 'Owner',
+            dataIndex: ['owner', 'name'],
+            key: 'owner',
+        },
+        {
+            title: 'Status',
+            dataIndex: 'status',
+            key: 'status',
+            render: (status: string) => (
+                <Tag color={status === 'PUBLISHED' ? 'green' : 'orange'}>{status}</Tag>
+            ),
+        },
+        {
+            title: 'Apps',
+            dataIndex: 'appCount',
+            key: 'appCount',
+            width: 80,
+            align: 'center' as const,
+        },
+        {
+            title: 'Actions',
+            key: 'actions',
+            width: 120,
+            render: (_: any, record: Collection) => {
+                const isDeleting = deletingId === record.id;
+                return (
+                    <Space>
+                        <TableActionButton
+                            actionType="edit"
+                            onClick={() => openEditModal(record)}
+                        />
+                        <Popconfirm
+                            title="Delete this collection?"
+                            onConfirm={() => handleDelete(record.id)}
+                            okText="Yes"
+                            cancelText="No"
+                            okButtonProps={{ loading: isDeleting }}
+                        >
+                            <Button
+                                type="text"
+                                danger
+                                icon={isDeleting ? <LoadingOutlined /> : undefined}
+                            >
+                                Delete
+                            </Button>
+                        </Popconfirm>
+                    </Space>
+                );
+            },
+        },
+    ];
+
+    return (
+        <div>
+            <div className="flex justify-between items-center mb-3">
+                <h2 className="font-bold text-lg">Manage Collections</h2>
+                <TableActionButton actionType="add" onClick={openCreateModal}>
+                    Add
+                </TableActionButton>
+            </div>
+            <div className="flex gap-4 mb-3">
+                <Input
+                    size="large"
+                    placeholder="Search by title"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    onPressEnter={() => { setPage(1); refetch(); }}
+                    prefix={<SearchOutlined className="text-secondary" />}
+                    className="rounded-lg"
+                />
+                <TableActionButton
+                    actionType="search"
+                    onClick={() => { setPage(1); refetch(); }}
+                >
+                    Search
+                </TableActionButton>
+            </div>
+            <Table
+                dataSource={data?.data || []}
+                columns={columns}
+                rowKey="id"
+                loading={isLoading}
+                pagination={{
+                    current: page,
+                    pageSize,
+                    total: data?.totalCount || 0,
+                    showSizeChanger: true,
+                    onChange: (p, s) => { setPage(p); setPageSize(s); },
+                }}
+                scroll={{ x: 'max-content' }}
+            />
+            <CollectionModal
+                open={isModalOpen}
+                onClose={() => { setIsModalOpen(false); setEditingCollection(null); }}
+                onSubmit={handleCreateOrUpdate}
+                initialValues={editingCollection}
+                isLoading={isCreating || isUpdating}
+            />
+        </div>
+    );
+};
+
+export default CollectionsPage;

--- a/frontend/src/validations/collection.validation.ts
+++ b/frontend/src/validations/collection.validation.ts
@@ -1,0 +1,16 @@
+import * as yup from 'yup';
+
+export const collectionSchema = yup.object({
+    title: yup
+        .string()
+        .trim()
+        .required('Title is required')
+        .max(255, 'Title must be at most 255 characters'),
+    description: yup.string().trim().optional(),
+    featuredImage: yup.string().optional(),
+    status: yup
+        .string()
+        .oneOf(['PRIVATE', 'PUBLISHED'], 'Invalid status')
+        .required('Status is required'),
+    appIds: yup.array().of(yup.string().required()).optional(),
+});


### PR DESCRIPTION
## Summary
Add admin management page for Collections at `/manage/collections`.

## What Changed
- Added route `/manage/collections` in admin sidebar.
- Created `CollectionsPage` with table (image, title, owner, status, app count) and search/pagination.
- Reusable `CollectionModal` for create/edit operations (all apps loaded via admin endpoint).
- yup validation for collection form.
- Soft‑delete with loading state and confirmation.

## How to Test
1. Log in as **admin**.
2. Navigate to `/manage/collections`.
3. Create a collection – verify table row appears.
4. Edit collection (change title, status, apps) – verify updates.
5. Delete a collection – check loading state and success.
6. Search by title – confirm filtering works.
7. Pagination – test page navigation.

## Affected Files
- `frontend/src/navigation/adminRoutePaths.tsx`
- `frontend/src/pages/AdminPage/AdminManageCollections/CollectionsPage.tsx`
- `frontend/src/pages/AdminPage/AdminManageCollections/components/CollectionModal.tsx`
- `frontend/src/validations/collection.validation.ts`